### PR TITLE
Don't throw an error if user presses Enter on an invalid undotree line

### DIFF
--- a/lua/undotree/collector.lua
+++ b/lua/undotree/collector.lua
@@ -320,6 +320,9 @@ function Collector:set_marks(cseq)
 end
 
 function Collector:undo2(cseq)
+  if cseq == nil then
+    return
+  end
   vim.cmd("noautocmd lua vim.api.nvim_set_current_win(" .. self.src_winid .. ")")
   local cmd
   if cseq == 0 then


### PR DESCRIPTION
Currently, if you press enter on an invalid undotree line, the following error is thrown:

![image](https://github.com/jiaoshijie/undotree/assets/20600565/96840594-adc6-4dfc-9977-62c2fd5917c6)

This diff handles that case without throwing an exception.

Note: This error state is only possible to reach if you have mouse support enabled. 