### PR TITLE
refactor: corrected (most) deprecations, massive code refactoring

### DIFF
--- a/lua/undotree/action.lua
+++ b/lua/undotree/action.lua
@@ -1,19 +1,29 @@
-local action = {}
+---@module 'undotree.collector'
 
-local enter = function(collector)
+local function enter(collector)
+  if not collector then
+    return
+  end
+
   local cseq = collector.undotree_info.line2seq[vim.fn.line('.')]
   collector:undo2(cseq)
   collector:reflash_diff()
 end
 
+---@class UndoTreeAction
+local action = {}
+
+---@param collector UndoTreeCollector
 function action.move_next(collector)
   collector:move_selection(1)
 end
 
+---@param collector UndoTreeCollector
 function action.move_prev(collector)
   collector:move_selection(-1)
 end
 
+---@param collector UndoTreeCollector
 function action.move2parent(collector)
   local cu = collector.undotree_info
   local parent_seq = cu.seq2parent[cu.line2seq[vim.fn.line('.')]]
@@ -21,28 +31,33 @@ function action.move2parent(collector)
   collector:move_selection(lnum - vim.fn.line('.'))
 end
 
+---@param collector UndoTreeCollector
 function action.move_change_next(collector)
   collector:move_selection(1, true)
   enter(collector)
 end
 
+---@param collector UndoTreeCollector
 function action.move_change_prev(collector)
   collector:move_selection(-1, true)
   enter(collector)
 end
 
+---@param collector UndoTreeCollector
 function action.action_enter(collector)
   enter(collector)
 end
 
+---@param collector UndoTreeCollector
 function action.enter_diffbuf(collector)
-  if collector.diff_win then
-    vim.cmd("noautocmd lua vim.api.nvim_set_current_win(" .. collector.diff_win .. ")")
-  else
-    vim.api.nvim_err_writeln("There is no diff window found!!!")
+  if not collector.diff_win then
+    error("There is no diff window found!!!", vim.log.levels.ERROR)
   end
+
+  vim.cmd("noautocmd lua vim.api.nvim_set_current_win(" .. collector.diff_win .. ")")
 end
 
+---@param collector UndoTreeCollector
 function action.quit(collector)
   collector:close()
 end

--- a/lua/undotree/collector.lua
+++ b/lua/undotree/collector.lua
@@ -1,4 +1,3 @@
-local conf = require('undotree.config')
 local undotree = require('undotree.undotree')
 local Diff = require("undotree.diff")
 local split_win = require("undotree.split_window")
@@ -8,12 +7,17 @@ local popup = require('plenary.popup')
 
 local if_nil = vim.F.if_nil
 
-local Collector = {}
-Collector.__index = Collector
-
+---@class UndoTreeCollector.Opts
 local default_opt = {
   float_diff = true, -- set this `true` will disable layout option
-  ignore_filetype = { 'undotree', 'undotreeDiff', 'qf', 'TelescopePrompt', 'spectre_panel', 'tsplayground' },
+  ignore_filetype =  {
+    'undotree',
+    'undotreeDiff',
+    'qf',
+    'TelescopePrompt',
+    'spectre_panel',
+    'tsplayground',
+  },
   undotree_info = undotree:new(),
   layout = "left_bottom", -- "left_bottom", "left_left_bottom"
   position = "left", -- "right", "bottom"
@@ -25,32 +29,33 @@ local default_opt = {
     width = 0,
   },
   keymaps = {
-    ['j'] = "move_next",
-    ['k'] = "move_prev",
-    ['gj'] = "move2parent",
-    ['J'] = "move_change_next",
-    ['K'] = "move_change_prev",
+    j = "move_next",
+    k = "move_prev",
+    gj = "move2parent",
+    J = "move_change_next",
+    K = "move_change_prev",
     ['<cr>'] = "action_enter",
-    ['p'] = "enter_diffbuf",
-    ['q'] = "quit",
+    p = "enter_diffbuf",
+    q = "quit",
   },
 }
 
-local find_star = function(lnum)
+
+local function find_star(lnum)
   local line = vim.fn.getline(lnum)
-  if line and line ~= "" then
-    local col = 1
-    while col <= #line do
-      if string.sub(line, col, col) == "*" then
-        return true, col - 1 -- found, position
-      end
-      col = col + 1
-    end
+  if not line or line == "" then
+    return false, 0
   end
-  return false, 0
+  local col = 1
+  while col <= #line do
+    if string.sub(line, col, col) == "*" then
+      return true, col - 1 -- found, position
+    end
+    col = col + 1
+  end
 end
 
-local buf_delete = function(bufnr)
+local function buf_delete(bufnr)
   if bufnr == nil then
     return
   end
@@ -70,7 +75,7 @@ local buf_delete = function(bufnr)
   end
 end
 
-local win_delete = function(win_id, force, bdelete)
+local function win_delete(win_id, force, bdelete)
   if win_id == nil or not vim.api.nvim_win_is_valid(win_id) then
     return
   end
@@ -87,37 +92,21 @@ local win_delete = function(win_id, force, bdelete)
   vim.api.nvim_win_close(win_id, force)
 end
 
+---@class UndoTreeCollector: UndoTreeCollector.Opts
+local Collector = {}
 
 function Collector:new(opts)
   opts = opts or {}
-  local obj = setmetatable({
-    float_diff = if_nil(opts.float_diff, default_opt.float_diff),
-    ignore_filetype = if_nil(opts.ignore_filetype, default_opt.ignore_filetype),
-    undotree_info = undotree:new(),
-    diff_previewer = Diff:new(),
-    layout = if_nil(opts.layout, default_opt.layout),
-    position = if_nil(opts.position, default_opt.position),
-  }, self)
 
-  obj.window = vim.deepcopy(default_opt.window)
-  if opts.window then
-    for k, v in pairs(opts.window) do
-      obj.window[k] = v
-    end
-  end
-
-  obj.keymaps = vim.deepcopy(default_opt.keymaps)
-  if opts.keymaps then
-    for k, v in pairs(opts.keymaps) do
-      obj.keymaps[k] = v
-    end
-  end
+  local obj = setmetatable(vim.tbl_deep_extend('keep', opts, default_opt, Collector), {
+    __index = Collector,
+  })
 
   return obj
 end
 
 function Collector:run()
-  if conf.contains(self.ignore_filetype, vim.bo.filetype) then
+  if vim.tbl_contains(self.ignore_filetype, vim.bo.filetype) then
     return
   end
 
@@ -125,7 +114,7 @@ function Collector:run()
   self.src_bufnr = vim.fn.bufnr()
 
   local line_count = vim.o.lines - vim.o.cmdheight
-  if vim.o.laststatus ~= 0 then
+  if vim.o.ls ~= 0 then
     line_count = line_count - 1
   end
   if vim.fn.exists('+winbar') ~= 0 and vim.o.winbar ~= "" then
@@ -133,13 +122,12 @@ function Collector:run()
   end
 
   local win_opts = self:get_window_option(vim.o.columns, line_count)
-
   local u_win, _ = split_win:create("", win_opts.undotree_opts)
 
   self.undotree_win = u_win
   self.undotree_bufnr = vim.api.nvim_win_get_buf(u_win)
 
-  vim.api.nvim_buf_set_option(self.undotree_bufnr, "filetype", "undotree")
+  vim.api.nvim_set_option_value("filetype", "undotree", { buf = self.undotree_bufnr })
 
   if self.float_diff then
     -- NOTE: _ is diff_opts
@@ -147,7 +135,7 @@ function Collector:run()
   else
     self.diff_win, _ = split_win:create("", win_opts.diff_opts)
     self.diff_bufnr = vim.api.nvim_win_get_buf(self.diff_win)
-    vim.api.nvim_buf_set_option(self.diff_bufnr, "filetype", "undotreeDiff")
+    vim.api.nvim_set_option_value("filetype", "undotreeDiff", { buf = self.diff_bufnr })
   end
 
   self:reflash_undotree(true)
@@ -181,11 +169,11 @@ end
 function Collector:create_popup_win(bufnr, popup_opts)
   local what = bufnr or ""
   local win, opts = popup.create(what, popup_opts)
-  vim.api.nvim_win_set_option(win, "winblend", self.window.winblend)
-  vim.api.nvim_win_set_option(win, "wrap", false)
+  vim.api.nvim_set_option_value("winblend", self.window.winblend, { win = win })
+  vim.api.nvim_set_option_value("wrap", false, { win = win })
   local border_win = opts and opts.border and opts.border.win_id
   if border_win then
-    vim.api.nvim_win_set_option(border_win, "winblend", self.window.winblend)
+    vim.api.nvim_set_option_value("winblend", self.window.winblend, { win = border_win })
   end
   return win, opts, border_win
 end
@@ -251,17 +239,20 @@ function Collector:reflash_undotree(always_flash)
   vim.cmd("noautocmd lua vim.api.nvim_set_current_win(" .. self.src_winid .. ")")
 
   local reflash = self.undotree_info:gen_graph_tree()
-  if always_flash == true or reflash == true then
-    vim.api.nvim_buf_set_option(self.undotree_bufnr, "modifiable", true)
-    vim.api.nvim_buf_set_lines(self.undotree_bufnr, 0, -1, false, self.undotree_info.char_graph)
-    vim.api.nvim_buf_set_option(self.undotree_bufnr, "modifiable", false)
+
+  if not (always_flash or reflash) then
+    return
   end
+
+  vim.api.nvim_set_option_value("modifiable", true, { buf = self.undotree_bufnr })
+  vim.api.nvim_buf_set_lines(self.undotree_bufnr, 0, -1, false, self.undotree_info.char_graph)
+  vim.api.nvim_set_option_value("modifiable", false, { buf = self.undotree_bufnr })
 end
 
 function Collector:move_selection(change, not_reflash)
   local lnum = vim.fn.line('.') + change
-  local col = 0
-  local found = false
+  local col, found = 0, false
+
   while lnum >= 1 and lnum <= vim.fn.line('$') do
     found, col = find_star(lnum)
     if found then
@@ -281,43 +272,45 @@ end
 
 function Collector:reflash_diff()
   local cursor_seq = self.undotree_info.line2seq[vim.fn.line('.')]
-  if cursor_seq == nil then return end
+
+  if cursor_seq == nil then
+    return
+  end
+
   local cseq = self.undotree_info.seq_cur
-  if self.float_diff then
-    if cursor_seq == cseq then
-      win_delete(self.diff_win, true, true)
-      win_delete(self.diff_border, true, true)
-      self.diff_bufnr = nil
-      self.diff_win = nil
-      return
-    elseif not self.diff_bufnr then
-      self.diff_win, _, self.diff_border = self:create_popup_win("", self.diff_win_opts)
-      self.diff_bufnr = vim.api.nvim_win_get_buf(self.diff_win)
-      vim.api.nvim_buf_set_option(self.diff_bufnr, "filetype", "undotreeDiff")
-    end
+  if self.float_diff and cursor_seq == cseq then
+    win_delete(self.diff_win, true, true)
+    win_delete(self.diff_border, true, true)
+    self.diff_bufnr = nil
+    self.diff_win = nil
+    return
+  elseif self.float_diff and not self.diff_bufnr then
+    self.diff_win, _, self.diff_border = self:create_popup_win("", self.diff_win_opts)
+    self.diff_bufnr = vim.api.nvim_win_get_buf(self.diff_win)
+    vim.api.nvim_set_option_value("filetype", "undotreeDiff", { buf = self.diff_bufnr })
   end
   local seq_last = self.undotree_info.seq_last
 
   self.diff_previewer:update_diff(self.src_bufnr, self.src_winid, self.undotree_win, cseq, cursor_seq, seq_last)
 
-  vim.api.nvim_buf_set_option(self.diff_bufnr, "modifiable", true)
+  vim.api.nvim_set_option_value("modifiable", true, { buf = self.diff_bufnr })
   vim.api.nvim_buf_set_lines(self.diff_bufnr, 0, -1, false, self.diff_previewer.diff_info)
   for i, hl in ipairs(self.diff_previewer.diff_highlight) do
     vim.api.nvim_buf_add_highlight(self.diff_bufnr, -1, hl, i - 1, 0, -1)
   end
-  vim.api.nvim_buf_set_option(self.diff_bufnr, "modifiable", false)
+  vim.api.nvim_set_option_value("modifiable", false, { buf = self.diff_bufnr })
 end
 
 function Collector:set_marks(cseq)
   -- >num< : The current state
   local seq_lnum = self.undotree_info.seq2line[cseq]
   local prev_seq_lnum = self.undotree_info.seq2line[self.undotree_info.seq_cur_bak]
-  vim.api.nvim_buf_set_option(self.undotree_bufnr, 'modifiable', true)
+  vim.api.nvim_set_option_value('modifiable', true, { buf = self.undotree_bufnr })
   if prev_seq_lnum ~= nil then
     vim.fn.setline(prev_seq_lnum, vim.fn.substitute(vim.fn.getline(prev_seq_lnum), '\\zs>\\(\\d\\+\\)<\\ze', '\\1', ''))
   end
   vim.fn.setline(seq_lnum, vim.fn.substitute(vim.fn.getline(seq_lnum), '\\zs\\(\\d\\+\\)\\ze', '>\\1<', ''))
-  vim.api.nvim_buf_set_option(self.undotree_bufnr, 'modifiable', false)
+  vim.api.nvim_set_option_value('modifiable', false, { buf = self.undotree_bufnr })
 end
 
 function Collector:undo2(cseq)

--- a/lua/undotree/config.lua
+++ b/lua/undotree/config.lua
@@ -1,19 +1,14 @@
-local _M = {}
+---@class UndoTreeConfig
+local M = {}
 
-function _M.contains(table, item)
-  for _, v in ipairs(table) do
-    if v == item then
-      return true
-    end
+function M.reverse_table(T)
+  local len = #T
+
+  for i = 1, math.floor(len / 2), 1 do
+    T[i], T[len - i + 1] = T[len - i + 1], T[i]
   end
-  return false
+
+  return T
 end
 
-function _M.reverse_table(input, output)
-  -- NOTE: `output` must be a empty table
-  for i = #input, 1, -1 do
-    table.insert(output, input[i])
-  end
-end
-
-return _M
+return M

--- a/lua/undotree/diff.lua
+++ b/lua/undotree/diff.lua
@@ -1,7 +1,4 @@
-local Diff = {}
-Diff.__index = Diff
-
-local undo2 = function(cseq, seq_last)
+local function undo2(cseq, seq_last)
   local cmd
   if cseq == 0 then
     cmd = string.format('silent exe "%s"', 'norm! ' .. seq_last .. 'u')
@@ -11,13 +8,17 @@ local undo2 = function(cseq, seq_last)
   vim.cmd(cmd)
 end
 
+---@class UndoTreeDiff
+local Diff = {}
+
 function Diff:new()
   local obj = setmetatable({
     old_seq = nil,
     new_seq = nil,
     diff_info = {},
     diff_highlight = {},
-  }, self)
+  }, { __index = Diff })
+
   return obj
 end
 
@@ -36,40 +37,41 @@ function Diff:update_diff(src_buf, src_win, undo_win, old_seq, new_seq, seq_last
   table.insert(self.diff_info, old_seq .. ' --> ' .. new_seq)
   table.insert(self.diff_highlight, 'UndotreeDiffLine')
 
-  if old_seq ~= new_seq then
-    local old_buf_con = vim.api.nvim_buf_get_lines(src_buf, 0, -1, false)
-    vim.cmd("noautocmd lua vim.api.nvim_set_current_win(" .. src_win .. ")")
-    local savedview = vim.fn.winsaveview()
-    undo2(new_seq, seq_last)
-    local new_buf_con = vim.api.nvim_buf_get_lines(src_buf, 0, -1, false)
-    undo2(old_seq, seq_last)
-    vim.fn.winrestview(savedview)
-    vim.cmd("noautocmd lua vim.api.nvim_set_current_win(" .. undo_win .. ")")
+  if old_seq == new_seq then
+    return
+  end
+  local old_buf_con = vim.api.nvim_buf_get_lines(src_buf, 0, -1, false)
+  vim.cmd("noautocmd lua vim.api.nvim_set_current_win(" .. src_win .. ")")
+  local savedview = vim.fn.winsaveview()
+  undo2(new_seq, seq_last)
+  local new_buf_con = vim.api.nvim_buf_get_lines(src_buf, 0, -1, false)
+  undo2(old_seq, seq_last)
+  vim.fn.winrestview(savedview)
+  vim.cmd("noautocmd lua vim.api.nvim_set_current_win(" .. undo_win .. ")")
 
-    local on_hunk_callback = function(start_old, count_old, start_new, count_new)
-      table.insert(self.diff_info,
-        "@@ -" .. start_old .. "," .. count_old .. " " .. start_new .. "," .. count_new .. " @@")
-      table.insert(self.diff_highlight, "UndotreeDiffLine")
-      if count_old ~= 0 then
-        for i = 0, count_old - 1 do
-          table.insert(self.diff_info, "- " .. old_buf_con[start_old + i])
-          table.insert(self.diff_highlight, "UndotreeDiffRemoved")
-        end
-      end
-      if count_new ~= 0 then
-        for i = 0, count_new - 1 do
-          table.insert(self.diff_info, "+ " .. new_buf_con[start_new + i])
-          table.insert(self.diff_highlight, "UndotreeDiffAdded")
-        end
+  local on_hunk_callback = function(start_old, count_old, start_new, count_new)
+    table.insert(self.diff_info,
+      "@@ -" .. start_old .. "," .. count_old .. " " .. start_new .. "," .. count_new .. " @@")
+    table.insert(self.diff_highlight, "UndotreeDiffLine")
+    if count_old ~= 0 then
+      for i = 0, count_old - 1 do
+        table.insert(self.diff_info, "- " .. old_buf_con[start_old + i])
+        table.insert(self.diff_highlight, "UndotreeDiffRemoved")
       end
     end
-
-    vim.diff(table.concat(old_buf_con, '\n'), table.concat(new_buf_con, '\n'), {
-      result_type = "indices",
-      on_hunk = on_hunk_callback,
-      algorithm = "histogram",
-    })
+    if count_new ~= 0 then
+      for i = 0, count_new - 1 do
+        table.insert(self.diff_info, "+ " .. new_buf_con[start_new + i])
+        table.insert(self.diff_highlight, "UndotreeDiffAdded")
+      end
+    end
   end
+
+  vim.diff(table.concat(old_buf_con, '\n'), table.concat(new_buf_con, '\n'), {
+    result_type = "indices",
+    on_hunk = on_hunk_callback,
+    algorithm = "histogram",
+  })
 end
 
 return Diff

--- a/lua/undotree/split_window.lua
+++ b/lua/undotree/split_window.lua
@@ -1,30 +1,33 @@
-local split_window = {}
 local if_nil = vim.F.if_nil
 
 local _unique_winbuf = 0
 
-local set_option = function(winid, bufnr)
+local function set_option(winid, bufnr)
   -- window options --
-  vim.api.nvim_win_set_option(winid, 'number', false)
-  vim.api.nvim_win_set_option(winid, 'relativenumber', false)
-  vim.api.nvim_win_set_option(winid, 'winfixwidth', true)
-  vim.api.nvim_win_set_option(winid, 'wrap', false)
-  vim.api.nvim_win_set_option(winid, 'spell', false)
-  vim.api.nvim_win_set_option(winid, 'cursorline', true)
-  vim.api.nvim_win_set_option(winid, 'signcolumn', 'no')
+  vim.api.nvim_set_option_value('number', false, { win = winid })
+  vim.api.nvim_set_option_value('relativenumber', false, { win = winid })
+  vim.api.nvim_set_option_value('winfixwidth', true, { win = winid })
+  vim.api.nvim_set_option_value('wrap', false, { win = winid })
+  vim.api.nvim_set_option_value('spell', false, { win = winid })
+  vim.api.nvim_set_option_value('cursorline', true, { win = winid })
+  vim.api.nvim_set_option_value('signcolumn', 'no', { win = winid })
   -- buf options --
-  vim.api.nvim_buf_set_option(bufnr, 'bufhidden', 'wipe') -- NOTE: or 'delete'
-  vim.api.nvim_buf_set_option(bufnr, 'buflisted', false)
-  vim.api.nvim_buf_set_option(bufnr, 'buftype', 'nowrite')
-  vim.api.nvim_buf_set_option(bufnr, 'swapfile', false)
-  -- vim.api.nvim_buf_set_option(bufnr, 'filetype', 'undotree')
-  vim.api.nvim_buf_set_option(bufnr, 'modifiable', false)
+  vim.api.nvim_set_option_value('bufhidden', 'wipe', { buf = bufnr }) -- NOTE: or 'delete'
+  vim.api.nvim_set_option_value('buflisted', false, { buf = bufnr })
+  vim.api.nvim_set_option_value('buftype', 'nowrite', { buf = bufnr })
+  vim.api.nvim_set_option_value('swapfile', false, { buf = bufnr })
+  -- vim.api.nvim_set_option_value('filetype', 'undotree', { buf = bufnr })
+  vim.api.nvim_set_option_value('modifiable', false, { buf = bufnr })
 end
+
+---@class UndoTreeSplitWindow
+local split_window = {}
 
 function split_window:create(what, opts)
   opts = opts or {}
   local size = 0
   local c_win_command = { "silent keepalt" }
+
   if opts.position == "bottom" then
     table.insert(c_win_command, "botright")
     size = if_nil(opts.size, math.floor(vim.o.lines * 0.30))
@@ -41,18 +44,17 @@ function split_window:create(what, opts)
 
   if type(what) == "number" then
     table.insert(c_win_command, "split")
+  elseif type(what) == "string" and what ~= "" then
+    table.insert(c_win_command, "new " .. what)
   elseif type(what) == "string" then
-    if what ~= "" then
-      table.insert(c_win_command, "new " .. what)
-    else
-      table.insert(c_win_command, "new [Scratch-" .. _unique_winbuf .. "]")
-      _unique_winbuf = _unique_winbuf + 1
-    end
+    table.insert(c_win_command, "new [Scratch-" .. _unique_winbuf .. "]")
+    _unique_winbuf = _unique_winbuf + 1
   end
 
   local prev_winid = vim.fn.win_getid()
   vim.cmd(table.concat(c_win_command, " "))
   local winid = vim.fn.win_getid()
+
   if type(what) == "number" then
     vim.api.nvim_win_set_buf(winid, what)
   end


### PR DESCRIPTION
## Changes

- Updated deprecated API calls (save for one)
- Added simple class annotations
- Massive code sections rewritten
- Dropped `config.contains`, since `vim.tbl_contains` exists
- Simplified `config.reverse_table`
- Many variable declarations compressed for readability
- Got rid of all `if x == true then` conditionals. These are redundant