### PR TITLE
fix: add `vim.validate`, documentation, formatting

### DIFF
--- a/lua/undotree.lua
+++ b/lua/undotree.lua
@@ -3,6 +3,8 @@ local Undotree = {}
 
 ---@param opt? UndoTreeCollector.Opts
 function Undotree.setup(opt)
+  vim.validate("opt", opt, "table", true, "UndoTreeCollector.Opts")
+
   local Coll = require("undotree.collector")
   Undotree.coll = Coll.new(opt or {})
 end

--- a/lua/undotree/action.lua
+++ b/lua/undotree/action.lua
@@ -1,7 +1,13 @@
 ---@module 'undotree.collector'
 
+local validate = vim.validate
+
+---@class UndoTreeAction
+local action = {}
+
 ---@param collector? UndoTreeCollector
-local function enter(collector)
+function action.enter(collector)
+  validate("collector", collector, "table", true, "UndoTreeCollector")
   if not collector then
     return
   end
@@ -11,21 +17,21 @@ local function enter(collector)
   collector:reflash_diff()
 end
 
----@class UndoTreeAction
-local action = {}
-
 ---@param collector UndoTreeCollector
 function action.move_next(collector)
+  validate("collector", collector, "table", false, "UndoTreeCollector")
   collector:move_selection(1)
 end
 
 ---@param collector UndoTreeCollector
 function action.move_prev(collector)
+  validate("collector", collector, "table", false, "UndoTreeCollector")
   collector:move_selection(-1)
 end
 
 ---@param collector UndoTreeCollector
 function action.move2parent(collector)
+  validate("collector", collector, "table", false, "UndoTreeCollector")
   local cu = collector.undotree_info
   local parent_seq = cu.seq2parent[cu.line2seq[vim.fn.line(".")]]
   local lnum = cu.seq2line[parent_seq]
@@ -34,23 +40,27 @@ end
 
 ---@param collector UndoTreeCollector
 function action.move_change_next(collector)
+  validate("collector", collector, "table", false, "UndoTreeCollector")
   collector:move_selection(1, true)
-  enter(collector)
+  action.enter(collector)
 end
 
 ---@param collector UndoTreeCollector
 function action.move_change_prev(collector)
+  validate("collector", collector, "table", false, "UndoTreeCollector")
   collector:move_selection(-1, true)
-  enter(collector)
+  action.enter(collector)
 end
 
 ---@param collector UndoTreeCollector
 function action.action_enter(collector)
-  enter(collector)
+  validate("collector", collector, "table", false, "UndoTreeCollector")
+  action.enter(collector)
 end
 
 ---@param collector UndoTreeCollector
 function action.enter_diffbuf(collector)
+  validate("collector", collector, "table", false, "UndoTreeCollector")
   if not collector.diff_win then
     error("There is no diff window found!!!", vim.log.levels.ERROR)
   end
@@ -60,6 +70,7 @@ end
 
 ---@param collector UndoTreeCollector
 function action.quit(collector)
+  validate("collector", collector, "table", false, "UndoTreeCollector")
   collector:close()
 end
 

--- a/lua/undotree/collector.lua
+++ b/lua/undotree/collector.lua
@@ -194,6 +194,8 @@ function Collector:run()
   })
 end
 
+---@param self UndoTreeCollector
+---@param bufnr? integer|string
 function Collector:create_popup_win(bufnr, popup_opts)
   local what = bufnr or ""
   local win, opts = popup.create(what, popup_opts)
@@ -206,6 +208,7 @@ function Collector:create_popup_win(bufnr, popup_opts)
   return win, opts, border_win
 end
 
+---@param self UndoTreeCollector
 ---@param max_columns integer
 ---@param max_lines integer
 ---@return UndoWinTree
@@ -245,7 +248,8 @@ function Collector:get_window_option(max_columns, max_lines)
     opts.diff_opts.line = math.floor((max_lines - height) / 2)
     opts.diff_opts.height = height
     opts.diff_opts.minheight = height
-    opts.diff_opts.borderchars = self.window.borderchars or { "─", "│", "─", "│", "╭", "╮", "╯", "╰" }
+    opts.diff_opts.borderchars = self.window.borderchars
+      or { "─", "│", "─", "│", "╭", "╮", "╯", "╰" }
     opts.diff_opts.title = "Diff Previewer"
 
     if self.position == "right" then
@@ -270,6 +274,7 @@ function Collector:get_window_option(max_columns, max_lines)
   return opts
 end
 
+---@param self UndoTreeCollector
 ---@param always_flash boolean
 function Collector:reflash_undotree(always_flash)
   vim.cmd("noautocmd lua vim.api.nvim_set_current_win(" .. self.src_winid .. ")")
@@ -285,6 +290,9 @@ function Collector:reflash_undotree(always_flash)
   vim.api.nvim_set_option_value("modifiable", false, { buf = self.undotree_bufnr })
 end
 
+---@param self UndoTreeCollector
+---@param change integer
+---@param not_reflash? boolean
 function Collector:move_selection(change, not_reflash)
   local lnum = vim.fn.line(".") + change
   local col, found = 0, false
@@ -299,6 +307,9 @@ function Collector:move_selection(change, not_reflash)
   end
 end
 
+---@param self UndoTreeCollector
+---@param pos [integer, integer]
+---@param not_reflash? boolean
 function Collector:set_selection(pos, not_reflash)
   vim.api.nvim_win_set_cursor(self.undotree_win, pos)
   if not not_reflash then
@@ -306,6 +317,7 @@ function Collector:set_selection(pos, not_reflash)
   end
 end
 
+---@param self UndoTreeCollector
 function Collector:reflash_diff()
   local cursor_seq = self.undotree_info.line2seq[vim.fn.line(".")]
 
@@ -340,11 +352,13 @@ function Collector:reflash_diff()
   vim.api.nvim_buf_set_lines(self.diff_bufnr, 0, -1, false, self.diff_previewer.diff_info)
   for i, hl in ipairs(self.diff_previewer.diff_highlight) do
     -- vim.api.nvim_buf_add_highlight(self.diff_bufnr, -1, hl, i - 1, 0, -1)
-    vim.hl.range(self.diff_bufnr, -1, hl, {i - 1, 0}, {i - 1, -1}, { timeout = -1 })
+    vim.hl.range(self.diff_bufnr, -1, hl, { i - 1, 0 }, { i - 1, -1 }, { timeout = -1 })
   end
   vim.api.nvim_set_option_value("modifiable", false, { buf = self.diff_bufnr })
 end
 
+---@param self UndoTreeCollector
+---@param cseq integer
 function Collector:set_marks(cseq)
   -- >num< : The current state
   local seq_lnum = self.undotree_info.seq2line[cseq]
@@ -363,10 +377,13 @@ function Collector:set_marks(cseq)
   vim.api.nvim_set_option_value("modifiable", false, { buf = self.undotree_bufnr })
 end
 
+---@param self UndoTreeCollector
+---@param cseq? integer
 function Collector:undo2(cseq)
   if cseq == nil then
     return
   end
+
   vim.cmd("noautocmd lua vim.api.nvim_set_current_win(" .. self.src_winid .. ")")
   local cmd
   if cseq == 0 then
@@ -380,6 +397,7 @@ function Collector:undo2(cseq)
   self:set_marks(cseq)
 end
 
+---@param self UndoTreeCollector
 function Collector:close()
   win_delete(self.undotree_win, true, true)
   win_delete(self.diff_win, true, true)

--- a/lua/undotree/config.lua
+++ b/lua/undotree/config.lua
@@ -4,8 +4,9 @@ local M = {}
 ---@param T table
 ---@return table T
 function M.reverse_table(T)
-  local len = #T
+  vim.validate("T", T, "table", false)
 
+  local len = #T
   for i = 1, math.floor(len / 2), 1 do
     T[i], T[len - i + 1] = T[len - i + 1], T[i]
   end

--- a/lua/undotree/diff.lua
+++ b/lua/undotree/diff.lua
@@ -1,8 +1,12 @@
 local fmt = string.format
+local validate = vim.validate
 
 ---@param cseq integer
 ---@param seq_last integer
 local function undo2(cseq, seq_last)
+  validate("cseq", cseq, "number", false, "integer")
+  validate("seq_last", seq_last, "number", false, "integer")
+
   local cmd =
     fmt('silent exe "%s"', (cseq == 0 and ("norm!" .. seq_last .. "u") or ("undo" .. cseq)))
   vim.cmd(cmd)
@@ -15,25 +19,28 @@ end
 ---@field diff_highlight table
 local Diff = {}
 
+---@param self UndoTreeDiff
 ---@return UndoTreeDiff obj
 function Diff:new()
-  local obj = setmetatable({
-    old_seq = nil,
-    new_seq = nil,
-    diff_info = {},
-    diff_highlight = {},
-  }, { __index = Diff })
+  local obj = setmetatable({}, { __index = Diff })
+
+  obj:set(nil, nil)
 
   return obj
 end
 
----@param old integer
----@param new integer
+---@param self UndoTreeDiff
+---@param old integer | nil
+---@param new integer | nil
 function Diff:set(old, new)
-  self.old_seq, self.new_seq = old, new
-  self.diff_info, self.diff_highlight = {}, {}
+  self.old_seq = old
+  self.new_seq = new
+
+  self.diff_info = {}
+  self.diff_highlight = {}
 end
 
+---@param self UndoTreeDiff
 ---@param src_buf integer
 ---@param src_win integer
 ---@param undo_win integer
@@ -41,6 +48,13 @@ end
 ---@param new_seq integer
 ---@param seq_last integer
 function Diff:update_diff(src_buf, src_win, undo_win, old_seq, new_seq, seq_last)
+  validate("src_buf", src_buf, "number", false, "integer")
+  validate("src_win", src_win, "number", false, "integer")
+  validate("undo_win", undo_win, "number", false, "integer")
+  validate("old_seq", old_seq, "number", false, "integer")
+  validate("new_seq", new_seq, "number", false, "integer")
+  validate("seq_last", seq_last, "number", false, "integer")
+
   if old_seq == self.old_seq and new_seq == self.new_seq then
     return
   end

--- a/lua/undotree/split_window.lua
+++ b/lua/undotree/split_window.lua
@@ -1,10 +1,14 @@
 local floor = math.floor
+local validate = vim.validate
 
 local _unique_winbuf = 0
 
 ---@param winid integer
 ---@param bufnr integer
 local function set_option(winid, bufnr)
+  validate("winid", winid, "number", false, "integer")
+  validate("bufnr", bufnr, "number", false, "integer")
+
   local opts_buf_set, opts_win_set = { buf = bufnr }, { win = winid }
 
   -- window options --
@@ -46,6 +50,9 @@ local split_window = {}
 ---@return integer winid
 ---@return integer prev_winid
 function split_window:create(what, opts)
+  validate("what", what, { "string", "number" }, false, "string|integer")
+  validate("opts", opts, "table", true, "UndoWinTree.Opts")
+
   opts = opts or {}
 
   local size, c_win_command = 0, { "silent keepalt" }


### PR DESCRIPTION
## Changes

- Added [`vim.validate()`](https://neovim.io/doc/user/lua.html#vim.validate()) in functions to avoid wrong parameter types
- Formatted with StyLua
- Improved `Diff.new()` constructor
- Made local `enter()` function member of `action`
- Documented most of the code

---

## Description

The plugin works as usual.

[`vim.validate()`](https://neovim.io/doc/user/lua.html#vim.validate()) is a good way to enforce specific types in code, and will make parameter parsing simpler.