### PR TITLE
fix: add `vim.validate` compatibility for older nvim versions

### DIFF
--- a/lua/undotree.lua
+++ b/lua/undotree.lua
@@ -3,10 +3,15 @@ local Undotree = {}
 
 ---@param opt? UndoTreeCollector.Opts
 function Undotree.setup(opt)
-  vim.validate("opt", opt, "table", true, "UndoTreeCollector.Opts")
+  if vim.fn.has("nvim-0.11") == 1 then
+    vim.validate("opt", opt, "table", true, "UndoTreeCollector.Opts")
+  else
+    vim.validate({ opt = { opt, { "table", "nil" } } })
+  end
+  opt = opt or {}
 
   local Coll = require("undotree.collector")
-  Undotree.coll = Coll.new(opt or {})
+  Undotree.coll = Coll.new(opt)
 end
 
 function Undotree.open()

--- a/lua/undotree/action.lua
+++ b/lua/undotree/action.lua
@@ -1,13 +1,16 @@
 ---@module 'undotree.collector'
 
-local validate = vim.validate
-
 ---@class UndoTreeAction
 local action = {}
 
 ---@param collector? UndoTreeCollector
 function action.enter(collector)
-  validate("collector", collector, "table", true, "UndoTreeCollector")
+  if vim.fn.has("nvim-0.11") == 1 then
+    vim.validate("collector", collector, "table", true, "UndoTreeCollector")
+  else
+    vim.validate({ collector = { collector, { "table", "nil" } } })
+  end
+
   if not collector then
     return
   end
@@ -19,19 +22,31 @@ end
 
 ---@param collector UndoTreeCollector
 function action.move_next(collector)
-  validate("collector", collector, "table", false, "UndoTreeCollector")
+  if vim.fn.has("nvim-0.11") == 1 then
+    vim.validate("collector", collector, "table", false, "UndoTreeCollector")
+  else
+    vim.validate({ collector = { collector, "table" } })
+  end
   collector:move_selection(1)
 end
 
 ---@param collector UndoTreeCollector
 function action.move_prev(collector)
-  validate("collector", collector, "table", false, "UndoTreeCollector")
+  if vim.fn.has("nvim-0.11") == 1 then
+    vim.validate("collector", collector, "table", false, "UndoTreeCollector")
+  else
+    vim.validate({ collector = { collector, "table" } })
+  end
   collector:move_selection(-1)
 end
 
 ---@param collector UndoTreeCollector
 function action.move2parent(collector)
-  validate("collector", collector, "table", false, "UndoTreeCollector")
+  if vim.fn.has("nvim-0.11") == 1 then
+    vim.validate("collector", collector, "table", false, "UndoTreeCollector")
+  else
+    vim.validate({ collector = { collector, "table" } })
+  end
   local cu = collector.undotree_info
   local parent_seq = cu.seq2parent[cu.line2seq[vim.fn.line(".")]]
   local lnum = cu.seq2line[parent_seq]
@@ -40,27 +55,43 @@ end
 
 ---@param collector UndoTreeCollector
 function action.move_change_next(collector)
-  validate("collector", collector, "table", false, "UndoTreeCollector")
+  if vim.fn.has("nvim-0.11") == 1 then
+    vim.validate("collector", collector, "table", false, "UndoTreeCollector")
+  else
+    vim.validate({ collector = { collector, "table" } })
+  end
   collector:move_selection(1, true)
   action.enter(collector)
 end
 
 ---@param collector UndoTreeCollector
 function action.move_change_prev(collector)
-  validate("collector", collector, "table", false, "UndoTreeCollector")
+  if vim.fn.has("nvim-0.11") == 1 then
+    vim.validate("collector", collector, "table", false, "UndoTreeCollector")
+  else
+    vim.validate({ collector = { collector, "table" } })
+  end
   collector:move_selection(-1, true)
   action.enter(collector)
 end
 
 ---@param collector UndoTreeCollector
 function action.action_enter(collector)
-  validate("collector", collector, "table", false, "UndoTreeCollector")
+  if vim.fn.has("nvim-0.11") == 1 then
+    vim.validate("collector", collector, "table", false, "UndoTreeCollector")
+  else
+    vim.validate({ collector = { collector, "table" } })
+  end
   action.enter(collector)
 end
 
 ---@param collector UndoTreeCollector
 function action.enter_diffbuf(collector)
-  validate("collector", collector, "table", false, "UndoTreeCollector")
+  if vim.fn.has("nvim-0.11") == 1 then
+    vim.validate("collector", collector, "table", false, "UndoTreeCollector")
+  else
+    vim.validate({ collector = { collector, "table" } })
+  end
   if not collector.diff_win then
     error("There is no diff window found!!!", vim.log.levels.ERROR)
   end
@@ -70,7 +101,11 @@ end
 
 ---@param collector UndoTreeCollector
 function action.quit(collector)
-  validate("collector", collector, "table", false, "UndoTreeCollector")
+  if vim.fn.has("nvim-0.11") == 1 then
+    vim.validate("collector", collector, "table", false, "UndoTreeCollector")
+  else
+    vim.validate({ collector = { collector, "table" } })
+  end
   collector:close()
 end
 

--- a/lua/undotree/collector.lua
+++ b/lua/undotree/collector.lua
@@ -350,10 +350,10 @@ function Collector:reflash_diff()
 
   local ns_dict = vim.api.nvim_get_namespaces()
   local ns
-  if not vim.tbl_contains(ns_dict, 'undotree') then
-    ns = vim.api.nvim_create_namespace('undotree')
+  if not vim.tbl_contains(ns_dict, "undotree") then
+    ns = vim.api.nvim_create_namespace("undotree")
   else
-    ns = ns_dict['undotree']
+    ns = ns_dict["undotree"]
   end
   vim.api.nvim_set_option_value("modifiable", true, { buf = self.diff_bufnr })
   vim.api.nvim_buf_set_lines(self.diff_bufnr, 0, -1, false, self.diff_previewer.diff_info)

--- a/lua/undotree/config.lua
+++ b/lua/undotree/config.lua
@@ -4,7 +4,11 @@ local M = {}
 ---@param T table
 ---@return table T
 function M.reverse_table(T)
-  vim.validate("T", T, "table", false)
+  if vim.fn.has("nvim-0.11") == 1 then
+    vim.validate("T", T, "table", false)
+  else
+    vim.validate({ T = { T, "table" } })
+  end
 
   local len = #T
   for i = 1, math.floor(len / 2), 1 do

--- a/lua/undotree/config.lua
+++ b/lua/undotree/config.lua
@@ -10,6 +10,10 @@ function M.reverse_table(T)
     vim.validate({ T = { T, "table" } })
   end
 
+  if vim.tbl_isempty(T) then
+    return T
+  end
+
   local len = #T
   for i = 1, math.floor(len / 2), 1 do
     T[i], T[len - i + 1] = T[len - i + 1], T[i]

--- a/lua/undotree/diff.lua
+++ b/lua/undotree/diff.lua
@@ -1,14 +1,19 @@
-local fmt = string.format
-local validate = vim.validate
-
 ---@param cseq integer
 ---@param seq_last integer
 local function undo2(cseq, seq_last)
-  validate("cseq", cseq, "number", false, "integer")
-  validate("seq_last", seq_last, "number", false, "integer")
+  if vim.fn.has("nvim-0.11") == 1 then
+    vim.validate("cseq", cseq, "number", false, "integer")
+    vim.validate("seq_last", seq_last, "number", false, "integer")
+  else
+    vim.validate({
+      cseq = { cseq, "number" },
+      seq_last = { seq_last, "number" },
+    })
+  end
 
-  local cmd =
-    fmt('silent exe "%s"', (cseq == 0 and ("norm!" .. seq_last .. "u") or ("undo" .. cseq)))
+  local cmd = ('silent exe "%s"'):format(
+    (cseq == 0 and ("norm!" .. seq_last .. "u") or ("undo" .. cseq))
+  )
   vim.cmd(cmd)
 end
 
@@ -48,19 +53,30 @@ end
 ---@param new_seq integer
 ---@param seq_last integer
 function Diff:update_diff(src_buf, src_win, undo_win, old_seq, new_seq, seq_last)
-  validate("src_buf", src_buf, "number", false, "integer")
-  validate("src_win", src_win, "number", false, "integer")
-  validate("undo_win", undo_win, "number", false, "integer")
-  validate("old_seq", old_seq, "number", false, "integer")
-  validate("new_seq", new_seq, "number", false, "integer")
-  validate("seq_last", seq_last, "number", false, "integer")
+  if vim.fn.has("nvim-0.11") == 1 then
+    vim.validate("src_buf", src_buf, "number", false, "integer")
+    vim.validate("src_win", src_win, "number", false, "integer")
+    vim.validate("undo_win", undo_win, "number", false, "integer")
+    vim.validate("old_seq", old_seq, "number", false, "integer")
+    vim.validate("new_seq", new_seq, "number", false, "integer")
+    vim.validate("seq_last", seq_last, "number", false, "integer")
+  else
+    vim.validate({
+      src_buf = { src_buf, "number" },
+      src_win = { src_win, "number" },
+      undo_win = { undo_win, "number" },
+      old_seq = { old_seq, "number" },
+      new_seq = { new_seq, "number" },
+      seq_last = { seq_last, "number" },
+    })
+  end
 
   if old_seq == self.old_seq and new_seq == self.new_seq then
     return
   end
 
   self:set(old_seq, new_seq)
-  table.insert(self.diff_info, fmt("%s --> %s", old_seq, new_seq))
+  table.insert(self.diff_info, ("%s --> %s"):format(old_seq, new_seq))
   table.insert(self.diff_highlight, "UndotreeDiffLine")
 
   if old_seq == new_seq then
@@ -86,7 +102,7 @@ function Diff:update_diff(src_buf, src_win, undo_win, old_seq, new_seq, seq_last
   local on_hunk_callback = function(start_old, count_old, start_new, count_new)
     table.insert(
       self.diff_info,
-      fmt("@@ -%s,%s ,%s @@", start_old, count_old, start_new, count_new)
+      ("@@ -%s,%s ,%s @@"):format(start_old, count_old, start_new, count_new)
     )
     table.insert(self.diff_highlight, "UndotreeDiffLine")
     if count_old ~= 0 then

--- a/lua/undotree/split_window.lua
+++ b/lua/undotree/split_window.lua
@@ -1,13 +1,19 @@
 local floor = math.floor
-local validate = vim.validate
 
 local _unique_winbuf = 0
 
 ---@param winid integer
 ---@param bufnr integer
 local function set_option(winid, bufnr)
-  validate("winid", winid, "number", false, "integer")
-  validate("bufnr", bufnr, "number", false, "integer")
+  if vim.fn.has("nvim-0.11") == 1 then
+    vim.validate("winid", winid, "number", false, "integer")
+    vim.validate("bufnr", bufnr, "number", false, "integer")
+  else
+    vim.validate({
+      winid = { winid, "number" },
+      bufnr = { bufnr, "number" },
+    })
+  end
 
   local opts_buf_set, opts_win_set = { buf = bufnr }, { win = winid }
 
@@ -50,9 +56,15 @@ local split_window = {}
 ---@return integer winid
 ---@return integer prev_winid
 function split_window:create(what, opts)
-  validate("what", what, { "string", "number" }, false, "string|integer")
-  validate("opts", opts, "table", true, "UndoWinTree.Opts")
-
+  if vim.fn.has("nvim-0.11") == 1 then
+    vim.validate("what", what, { "string", "number" }, false, "string|integer")
+    vim.validate("opts", opts, "table", true, "UndoWinTree.Opts")
+  else
+    vim.validate({
+      what = { what, { "string", "number" } },
+      opts = { opts, { "table", "nil" } },
+    })
+  end
   opts = opts or {}
 
   local size, c_win_command = 0, { "silent keepalt" }

--- a/lua/undotree/undotree.lua
+++ b/lua/undotree/undotree.lua
@@ -1,6 +1,4 @@
-local fmt = string.format
 local mf = math.floor
-local validate = vim.validate
 
 ---@class OtherInfo
 ---@field save integer
@@ -13,28 +11,32 @@ local conf = require("undotree.config")
 ---@param ptime integer
 ---@return string
 local function time_ago(ptime)
-  validate("ptime", ptime, "number", false, "integer")
-  local sec = vim.fn.localtime() - ptime
+  if vim.fn.has("nvim-0.11") == 1 then
+    vim.validate("ptime", ptime, "number", false, "integer")
+  else
+    vim.validate({ ptime = { ptime, "number" } })
+  end
 
+  local sec = vim.fn.localtime() - ptime
   local mft
 
   if sec < 60 then
     mft = mf(sec)
-    return fmt("(%s %s ago)", mft, (mft > 1 and "secs" or "sec"))
+    return ("(%s %s ago)"):format(mft, (mft > 1 and "secs" or "sec"))
   end
 
   if sec < 3600 then
     mft = mf(sec / 60)
-    return fmt("(%s %s ago)", mft, (mft > 1 and "mins" or "min"))
+    return ("(%s %s ago)"):format(mft, (mft > 1 and "mins" or "min"))
   end
 
   if sec < 86400 then
     mft = mf(sec / 3600)
-    return fmt("(%s %s ago)", mft, (mft > 1 and "hours" or "hour"))
+    return ("(%s %s ago)"):format(mft, (mft > 1 and "hours" or "hour"))
   end
 
   mft = mf(sec / 86400)
-  return fmt("(%s %s ago)", mft, (mft > 1 and "days" or "day"))
+  return ("(%s %s ago)"):format(mft, (mft > 1 and "days" or "day"))
 end
 
 ---@class UndoTreeNode
@@ -51,9 +53,17 @@ local Node = {}
 ---@param save integer|nil
 ---@return UndoTreeNode node
 function Node.new(seq, time, save)
-  validate("seq", seq, "number", false, "integer")
-  validate("time", time, { "nil", "number" }, false, "integer|nil")
-  validate("save", save, { "nil", "number" }, false, "integer|nil")
+  if vim.fn.has("nvim-0.11") then
+    vim.validate("seq", seq, "number", false, "integer")
+    vim.validate("time", time, { "nil", "number" }, false, "integer|nil")
+    vim.validate("save", save, { "nil", "number" }, false, "integer|nil")
+  else
+    vim.validate({
+      seq = { seq, "number" },
+      time = { time, { "nil", "number" } },
+      save = { save, { "nil", "number" } },
+    })
+  end
 
   local node = setmetatable({}, { __index = Node })
   node.seq = seq
@@ -67,8 +77,15 @@ end
 ---@param input vim.fn.undotree.entry[]
 ---@param output UndoTreeNode
 local function parse_entries(input, output)
-  validate("input", input, "table", false, "vim.fn.undotree.entry[]")
-  validate("output", output, "table", false, "UndoTreeNode")
+  if vim.fn.has("nvim-0.11") then
+    vim.validate("input", input, "table", false, "vim.fn.undotree.entry[]")
+    vim.validate("output", output, "table", false, "UndoTreeNode")
+  else
+    vim.validate({
+      input = { input, "table" },
+      output = { output, "table" },
+    })
+  end
 
   if vim.tbl_isempty(input) then
     return
@@ -89,8 +106,15 @@ end
 ---@param indent integer
 ---@return integer ind
 local function gen_indentions(tree, indent)
-  validate("tree", tree, "table", false, "UndoTreeNode")
-  validate("indent", indent, "number", false, "integer")
+  if vim.fn.has("nvim-0.11") then
+    vim.validate("tree", tree, "table", false, "UndoTreeNode")
+    vim.validate("indent", indent, "number", false, "integer")
+  else
+    vim.validate({
+      tree = { tree, "table" },
+      indent = { indent, "number" },
+    })
+  end
 
   tree.indent = indent
   local ind = tree.indent
@@ -110,10 +134,19 @@ end
 ---@param char string
 ---@param indent integer
 local function set_line(graph, index, char, indent)
-  validate("graph", graph, "table", false, "string[]")
-  validate("index", index, "number", false, "integer")
-  validate("char", char, "string", false)
-  validate("indent", indent, "number", false, "integer")
+  if vim.fn.has("nvim-0.11") then
+    vim.validate("graph", graph, "table", false, "string[]")
+    vim.validate("index", index, "number", false, "integer")
+    vim.validate("char", char, "string", false)
+    vim.validate("indent", indent, "number", false, "integer")
+  else
+    vim.validate({
+      graph = { graph, "table" },
+      index = { index, "number" },
+      char = { char, "string" },
+      indent = { indent, "number" },
+    })
+  end
 
   if vim.tbl_isempty(graph) then
     error("undotree - set_line: empty graph!")
@@ -137,12 +170,23 @@ end
 ---@param parent_ind integer
 ---@return boolean
 local function draw(tree, graph, line2seq, other_info, seq, parent_ind)
-  validate("tree", tree, "table", false, "UndoTreeNode")
-  validate("graph", graph, "table", false, "string[]")
-  validate("line2seq", line2seq, "table", false, "integer[]")
-  validate("other_info", other_info, "table", false, "OtherInfo[]")
-  validate("seq", seq, "number", false, "integer")
-  validate("parent_ind", parent_ind, "number", false, "integer")
+  if vim.fn.has("nvim-0.11") then
+    vim.validate("tree", tree, "table", false, "UndoTreeNode")
+    vim.validate("graph", graph, "table", false, "string[]")
+    vim.validate("line2seq", line2seq, "table", false, "integer[]")
+    vim.validate("other_info", other_info, "table", false, "OtherInfo[]")
+    vim.validate("seq", seq, "number", false, "integer")
+    vim.validate("parent_ind", parent_ind, "number", false, "integer")
+  else
+    vim.validate({
+      tree = { tree, "table" },
+      graph = { graph, "table" },
+      line2seq = { line2seq, "table" },
+      other_info = { other_info, "table" },
+      seq = { seq, "number" },
+      parent_ind = { parent_ind, "number" },
+    })
+  end
 
   if tree.seq == seq then
     local parent_lnum = other_info[tree.parent].lnum
@@ -191,11 +235,21 @@ end
 ---@param other_info OtherInfo[]
 ---@param last_seq integer
 local function gen_graph(tree, graph, line2seq, other_info, last_seq)
-  validate("tree", tree, "table", false, "UndoTreeNode")
-  validate("graph", graph, "table", false, "string[]")
-  validate("line2seq", line2seq, "table", false, "integer[]")
-  validate("other_info", other_info, "table", false, "OtherInfo[]")
-  validate("last_seq", last_seq, "number", false, "integer")
+  if vim.fn.has("nvim-0.11") == 1 then
+    vim.validate("tree", tree, "table", false, "UndoTreeNode")
+    vim.validate("graph", graph, "table", false, "string[]")
+    vim.validate("line2seq", line2seq, "table", false, "integer[]")
+    vim.validate("other_info", other_info, "table", false, "OtherInfo[]")
+    vim.validate("last_seq", last_seq, "number", false, "integer")
+  else
+    vim.validate({
+      tree = { tree, "table" },
+      graph = { graph, "table" },
+      line2seq = { line2seq, "table" },
+      other_info = { other_info, "table" },
+      last_seq = { last_seq, "number" },
+    })
+  end
 
   local cur_seq = 1
   while cur_seq <= last_seq do

--- a/plugin/undotree.lua
+++ b/plugin/undotree.lua
@@ -15,6 +15,6 @@ for k, v in pairs(highlights) do
   vim.api.nvim_set_hl(0, k, v)
 end
 
-require('undotree').setup()
+require("undotree").setup()
 
 -- vim:ts=2:sts=2:sw=2:et:ai:si:sta:


### PR DESCRIPTION
## Changes

- Added `vim.validate` checks to be compatible with Neovim versions lower than `v0.11`
- Format with StyLua