### PR TITLE
Guard move2parent on missing parent

### DIFF
--- a/lua/undotree/action.lua
+++ b/lua/undotree/action.lua
@@ -23,7 +23,12 @@ _M.move2parent = function(rt_ctx, rt_ops)
         return
     end
     local seq = seqline.seq_node.parent_seq
-    rt_ops.set_cursor(rt_ctx.seq2line[seq], 0)
+    local lnum = rt_ctx.seq2line[seq]
+    -- root (or missing) parent should not move the cursor.
+    if not lnum then
+        return
+    end
+    rt_ops.set_cursor(lnum, 0)
 end
 
 --- @param rt_ctx table runtime_ctx


### PR DESCRIPTION
## Note
This PR was created with the assistance of an AI/LLM. Please review carefully.

## What changed
- Guard `move2parent` when the current node has no valid parent entry.
- If `parent_seq` does not map to a line (e.g., root/origin node), we now return early instead of calling `set_cursor` with `nil`.

## Why
`move2parent` previously assumed every node had a parent line in `seq2line`. On the root entry, `parent_seq` is typically `-1` (or otherwise absent), so `seq2line[seq]` is `nil`. Passing `nil` into `set_cursor` could raise an error or cause undefined behavior.

## Behavior change
Pressing the parent-jump key on the root/origin node now becomes a no-op instead of erroring.