### PR TITLE
fix!: update keymaps table and resolve default keymap issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,18 +92,20 @@ require('undotree').setup({
     parser = "compact",
 
     keymaps = {
-        ["j"] = "move_next",
-        ["k"] = "move_prev",
-        ["gj"] = "move2parent",
-        ["J"] = "move_change_next",
-        ["K"] = "move_change_prev",
-        ["<cr>"] = "action_enter",
-        ["p"] = "enter_diffbuf", -- this can switch between preview and undotree window
-        ["q"] = "quit",
-        ["S"] = "update_undotree_view",
+        ["move_next"] = "j",
+        ["move_prev"] = "k",
+        ["move2parent"] = "gj",
+        ["move_change_next"] = "J",
+        ["move_change_prev"] = "K",
+        ["action_enter"] = "<cr>",
+        ["enter_diffbuf"] = "p", -- is defined for both undotree and preview buffers, so it works as a toggle
+        ["quit"] = "q", -- is defined for both undotree and preview buffers
+        ["update_undotree_view"] = "S",
     },
 })
 ```
+> [!IMPORTANT]
+> There was a breaking change introduced in #46. The action and the left-hand-side switched places in the `keymaps` table.
 
 ### Keymaps
 

--- a/lua/undotree/config.lua
+++ b/lua/undotree/config.lua
@@ -22,15 +22,15 @@ _M.ui_cfg = {
 }
 
 _M.keymaps_cfg = {
-    ["j"] = "move_next",
-    ["k"] = "move_prev",
-    ["gj"] = "move2parent",
-    ["J"] = "move_change_next",
-    ["K"] = "move_change_prev",
-    ["<cr>"] = "action_enter",
-    ["p"] = "enter_diffbuf", -- this can switch between preview and undotree window
-    ["q"] = "quit",
-    ["S"] = "update_undotree_view",
+    ["move_next"] = "j",
+    ["move_prev"] = "k",
+    ["move2parent"] = "gj",
+    ["move_change_next"] = "J",
+    ["move_change_prev"] = "K",
+    ["action_enter"] = "<cr>",
+    ["enter_diffbuf"] = "p", -- is defined for both undotree and preview buffers, so it works as a toggle
+    ["quit"] = "q", -- is defined for both undotree and preview buffers
+    ["update_undotree_view"] = "S",
 }
 
 -- NOTE: this code is ugly, but it's for backward compatibility
@@ -47,6 +47,27 @@ _M.setup = function(cfg)
     cfg.parser = nil
 
     if type(cfg.keymaps) == "table" then
+        -- backward compatibility for old keymaps table
+        local next_key, _ = next(cfg.keymaps)
+        if _M.keymaps_cfg[next_key] == nil then
+            vim.defer_fn(function()
+                vim.notify(
+                    "WARNING: `keymaps = { [lhs] = action }` is deprecated; "
+                        .. "use `keymaps = { [action] = lhs }` instead.\n"
+                        .. "See `:h undotree-configuration` for details.",
+                    vim.log.levels.WARN,
+                    { title = "Undotree Config", timeout = 5000 }
+                )
+            end, 500)
+            -- NOTE: the only issue of flipping will be if the user
+            -- for some reason uses multiple keymaps for the same action
+            local flipped_keymaps = {}
+            for k, v in pairs(cfg.keymaps) do
+                flipped_keymaps[v] = k
+            end
+            cfg.keymaps = flipped_keymaps
+        end
+
         _M.keymaps_cfg = vim.tbl_extend("force", _M.keymaps_cfg, cfg.keymaps)
     end
     cfg.keymaps = nil

--- a/lua/undotree/runtime.lua
+++ b/lua/undotree/runtime.lua
@@ -233,8 +233,7 @@ end
 
 _M.apply = function(lnum)
     local seqline = ctx.line2seq[lnum]
-    if not seqline or not seqline.seq_node
-        or ctx.cur_seq == seqline.seq_node.seq then
+    if not seqline or not seqline.seq_node or ctx.cur_seq == seqline.seq_node.seq then
         return
     end
     ctx.prev_seq = ctx.cur_seq

--- a/lua/undotree/runtime.lua
+++ b/lua/undotree/runtime.lua
@@ -132,15 +132,15 @@ local set_keymaps = function()
     local map_opts = { noremap = true, silent = true, buffer = ctx.bufnr }
 
     for k, v in pairs(cfg.keymaps_cfg) do
-        vim.keymap.set("n", k, function()
-            action[v](ctx, _M)
+        vim.keymap.set("n", v, function()
+            action[k](ctx, _M)
         end, map_opts)
     end
     map_opts.buffer = ctx.p_bufnr
-    vim.keymap.set("n", "p", function()
+    vim.keymap.set("n", cfg.keymaps_cfg["enter_diffbuf"], function()
         action["enter_diffbuf"](ctx, _M)
     end, map_opts)
-    vim.keymap.set("n", "q", function()
+    vim.keymap.set("n", cfg.keymaps_cfg["quit"], function()
         _M.close()
     end, map_opts)
 end


### PR DESCRIPTION
The following issues are resolved:
- the default keymaps are always defined, no matter if they are modified in user config
- the 2 keymaps "p" and "q" for the preview buffer are hardcoded

BREAKING CHANGE: keymaps table was changed from
```lua
keymaps = {
    ["j"] = "move_next",
    ["k"] = "move_prev",
    ["gj"] = "move2parent",
    ["J"] = "move_change_next",
    ["K"] = "move_change_prev",
    ["<cr>"] = "action_enter",
    ["p"] = "enter_diffbuf",
    ["q"] = "quit",
    ["S"] = "update_undotree_view",
},
```

to

```lua
keymaps = {
    ["move_next"] = "j",
    ["move_prev"] = "k",
    ["move2parent"] = "gj",
    ["move_change_next"] = "J",
    ["move_change_prev"] = "K",
    ["action_enter"] = "<cr>",
    ["enter_diffbuf"] = "p",
    ["quit"] = "q",
    ["update_undotree_view"] = "S",
}
```

The users will be notified of their config being outdated, but the keymaps should still be defined correctly.

Fixes #45